### PR TITLE
fix: Add Icecast environment variables for app service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,9 +24,13 @@ services:
       - R2_BUCKET_NAME=${R2_BUCKET_NAME:-}
       - R2_PUBLIC_URL=${R2_PUBLIC_URL:-}
       # Icecast
+      - ICECAST_HOST=icecast
+      - ICECAST_PORT=8000
       - ICECAST_URL=http://icecast:8000
       - ICECAST_STREAM_URL=http://icecast:8000/stream
       - ICECAST_SOURCE_PASSWORD=${ICECAST_SOURCE_PASSWORD:-}
+      - ICECAST_ADMIN_USER=${ICECAST_ADMIN_USER:-admin}
+      - ICECAST_ADMIN_PASSWORD=${ICECAST_ADMIN_PASSWORD:-}
       # API Security
       - API_SECRET_KEY=${API_SECRET_KEY:-}
       - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-http://localhost:3000}


### PR DESCRIPTION
## Summary

Add missing Icecast environment variables to the app service in docker-compose.yml. The audio-stream route needs ICECAST_HOST and ICECAST_PORT to connect to Icecast and check stream health. Also adds ICECAST_ADMIN_USER and ICECAST_ADMIN_PASSWORD for stats API authentication.

## Changes

- ICECAST_HOST=icecast (internal Docker service name)
- ICECAST_PORT=8000 
- ICECAST_ADMIN_USER and ICECAST_ADMIN_PASSWORD for stats checks

This fixes the ECONNREFUSED errors when the app tries to connect to Icecast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Versão

* **Chores**
  * Adicionadas variáveis de ambiente para configuração do Icecast, incluindo host, porta e credenciais administrativas
  * Melhorada a configuração de integração com serviços de streaming de áudio

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->