### PR TITLE
fix: Add command to run radio.liq in Liquidsoap

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,7 @@ services:
     image: savonet/liquidsoap:v2.3.3
     depends_on:
       - icecast
+    command: ["liquidsoap", "/radio/radio.liq"]
     environment:
       - ICECAST_SOURCE_PASSWORD=${ICECAST_SOURCE_PASSWORD:-hackme}
       - ICECAST_HOST=icecast


### PR DESCRIPTION
## Summary

The Liquidsoap container was starting but not executing any script, causing it to output "No output defined, nothing to do." This fixes the issue by explicitly specifying the command to run the radio.liq script.

## Changes

- Added `command: ["liquidsoap", "/radio/radio.liq"]` to Liquidsoap service
- This ensures the streaming script starts automatically when the container starts

This enables Liquidsoap to connect to the app and Icecast, allowing the 24/7 stream to function properly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **Chores**
  * Otimização na configuração de deployment do serviço para melhor execução e confiabilidade.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->