### PR TITLE
fix: Build Liquidsoap with Dockerfile instead of volume mount

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,19 +85,17 @@ services:
       - ICECAST_MAX_SOURCES=2
 
   liquidsoap:
-    image: savonet/liquidsoap:v2.3.3
+    build:
+      context: ./streaming/liquidsoap
+      dockerfile: Dockerfile
     depends_on:
       - icecast
-    command: ["liquidsoap", "/radio/radio.liq"]
     environment:
       - ICECAST_SOURCE_PASSWORD=${ICECAST_SOURCE_PASSWORD:-hackme}
       - ICECAST_HOST=icecast
       - ICECAST_PORT=8000
       - API_HOST=app
       - API_PORT=3000
-    volumes:
-      - ./streaming/liquidsoap:/radio:ro
-      - music-data:/music
 
 volumes:
   redis-data:

--- a/streaming/liquidsoap/Dockerfile
+++ b/streaming/liquidsoap/Dockerfile
@@ -1,0 +1,7 @@
+FROM savonet/liquidsoap:v2.3.3
+
+# Copy the radio script into the container
+COPY radio.liq /radio/radio.liq
+
+# Run liquidsoap with the script
+CMD ["liquidsoap", "/radio/radio.liq"]


### PR DESCRIPTION
## Summary

Volume mounts with relative paths don't work reliably in Coolify's Docker Compose deployments. This change builds the Liquidsoap image with the radio.liq script embedded instead of mounting it at runtime.

## Changes

- Created `streaming/liquidsoap/Dockerfile` that copies and runs the radio.liq script
- Updated `docker-compose.yml` to use `build` instead of `image` + volume mount
- Removed unused volume mounts

This ensures the Liquidsoap container is deployed correctly and can start the streaming pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **Chores**
  * Reorganização da infraestrutura de containerização do serviço de streaming, consolidando configurações de execução para melhor estrutura do processo de inicialização.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->