### PR TITLE
fix: Use correct Liquidsoap 2.x syntax for environment.get

### DIFF
--- a/streaming/liquidsoap/radio.liq
+++ b/streaming/liquidsoap/radio.liq
@@ -6,13 +6,14 @@ set("log.level", 3)
 set("server.telnet", false)
 
 # --- Environment Configuration ---
-api_host = environment.get("API_HOST", "app")
-api_port = environment.get("API_PORT", "3000")
+# Liquidsoap 2.x requires named 'default' parameter
+api_host = environment.get(default="app", "API_HOST")
+api_port = environment.get(default="3000", "API_PORT")
 api_base = "http://#{api_host}:#{api_port}"
 
-icecast_host = environment.get("ICECAST_HOST", "icecast")
-icecast_port = int_of_string(environment.get("ICECAST_PORT", "8000"))
-icecast_password = environment.get("ICECAST_SOURCE_PASSWORD", "hackme")
+icecast_host = environment.get(default="icecast", "ICECAST_HOST")
+icecast_port = int_of_string(environment.get(default="8000", "ICECAST_PORT"))
+icecast_password = environment.get(default="hackme", "ICECAST_SOURCE_PASSWORD")
 
 log("Liquidsoap: Using API at #{api_base}")
 log("Liquidsoap: Using Icecast at #{icecast_host}:#{icecast_port}")


### PR DESCRIPTION
## Summary

Liquidsoap 2.x changed the API for environment variables. The `default` parameter must be named explicitly. This fixes the "Cannot apply that parameter" errors that were preventing the container from starting.

## Changes

- Updated all `environment.get()` calls to use named `default` parameter
- Changed from: `environment.get("VAR", "default")`  
- To: `environment.get(default="default", "VAR")`

This allows the Liquidsoap container to parse and execute the radio.liq script correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **Refactor**
  * Atualização de compatibilidade com Liquidsoap 2.x através da modernização da sintaxe de parâmetros de configuração, mantendo os mesmos valores padrão para conectividade e autenticação.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->