### PR TITLE
fix: Prevent jsdom bundling to fix production CSS error

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -11,6 +11,20 @@ const nextConfig: NextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
+  // Prevent jsdom (used by isomorphic-dompurify) from being bundled server-side
+  // jsdom tries to load default-stylesheet.css which fails in production
+  serverExternalPackages: ['jsdom', 'isomorphic-dompurify'],
+  // Use webpack to externalize jsdom on server-side
+  webpack: (config, { isServer }) => {
+    if (isServer) {
+      config.externals = config.externals || [];
+      config.externals.push({
+        'jsdom': 'commonjs jsdom',
+        'isomorphic-dompurify': 'commonjs isomorphic-dompurify',
+      });
+    }
+    return config;
+  },
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
## Summary

- Fixes the `ENOENT: no such file or directory, open '/app/.next/server/browser/default-stylesheet.css'` production error
- Root cause: `isomorphic-dompurify` uses `jsdom` which tries to load a CSS file at runtime using `path.resolve()`
- Solution: Configure Next.js to externalize `jsdom` and `isomorphic-dompurify` on server-side builds

## Test plan

- [x] Local build succeeds without the `default-stylesheet` reference in the bundled files
- [ ] Deploy to production and verify no ENOENT errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Otimização da configuração de build para melhorar o processamento de dependências no servidor.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->