### PR TITLE
fix: Use newly created session credentials when initializing socket

### DIFF
--- a/src/lib/socket/client.ts
+++ b/src/lib/socket/client.ts
@@ -167,6 +167,8 @@ export function useSocket() {
           initializingRef.current = true;
 
           let token = session?.token;
+          let userId = session?.userId;
+          let username = session?.username;
 
           // If no session, try to restore or create one
           if (!token) {
@@ -186,7 +188,7 @@ export function useSocket() {
             // Maybe we connect unauthenticated first? Or wait?
             // The original code auto-created a guest token.
 
-            // Let's keep the auto-creation for now if no session exists, 
+            // Let's keep the auto-creation for now if no session exists,
             // but use the loginAsGuest from the hook to persist it.
             if (!session) {
               try {
@@ -194,6 +196,8 @@ export function useSocket() {
                 const storedUsername = localStorage.getItem('username'); // Legacy check?
                 const newSession = await loginAsGuest(storedUsername || undefined);
                 token = newSession.token;
+                userId = newSession.userId;
+                username = newSession.username;
               } catch (e) {
                 console.error('Failed to auto-login guest', e);
               }
@@ -206,12 +210,12 @@ export function useSocket() {
               : null;
             const preferredLocale: 'pt' | 'en' = pathLocale === 'en' ? 'en' : 'pt';
 
-            console.log('[Client] Initializing socket with token', { userId: session?.userId, username: session?.username, preferredLocale });
+            console.log('[Client] Initializing socket with token', { userId, username, preferredLocale });
             currentTokenRef.current = token;
             socket = initializeSocket({
               token,
-              userId: session?.userId,
-              username: session?.username,
+              userId,
+              username,
               locale: preferredLocale
             });
             setSocketInstance(socket);

--- a/src/lib/socket/server.ts
+++ b/src/lib/socket/server.ts
@@ -208,6 +208,10 @@ function setupEventHandlers(io: SocketIOServer<ClientToServerEvents, ServerToCli
       await redisHelpers.addListener(socket.id);
       await redisHelpers.markUserActive(userId);
 
+      // Immediately sync the server-assigned username back to the client
+      // This ensures the client always uses the authoritative username from the server
+      socket.emit(SOCKET_EVENTS.USER_UPDATE, { username });
+
       await syncClientState(socket);
 
       // Get fresh count after all operations to avoid race conditions


### PR DESCRIPTION
## Description

Fixes the username mismatch bug where guest users would enter as "Guest v887r5qkqm" but their messages would appear as "user_cv8jt" in the chat. The issue occurred because the socket handshake was using null/undefined credentials instead of the newly created session credentials.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Fixed socket initialization to use the newly created session's userId and username when auto-creating guest sessions
- Previously, the code stored only the token from the new session while still using the old (null) session for userId/username
- Now properly propagates all credentials to the socket handshake auth object

## Testing

- Type checking: ✓
- Unit tests: ✓
- Manual testing: Guest login now preserves the assigned username in messages

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Correções de Bugs**
  * Melhorias na propagação da identidade do usuário durante a inicialização do socket, garantindo preservação de token, ID e nome mesmo ao criar sessão de convidado automaticamente.

* **Novidades**
  * Sincronização imediata do nome de usuário enviada pelo servidor ao conectar, assegurando que o cliente receba o nome atualizado antes da sincronização de estado.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->