### PR TITLE
feat: add pulsating play button animation when autoplay is blocked

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -38,6 +38,7 @@ export default {
         'slide-down': 'slideDown 0.5s ease-out',
         'scale-in': 'scaleIn 0.3s ease-out',
         'bounce-subtle': 'bounceSubtle 2s ease-in-out infinite',
+        'pulse-attention': 'pulseAttention 1.5s ease-in-out infinite',
       },
       keyframes: {
         fadeIn: {
@@ -63,6 +64,16 @@ export default {
         bounceSubtle: {
           '0%, 100%': { transform: 'translateY(0)' },
           '50%': { transform: 'translateY(-5px)' },
+        },
+        pulseAttention: {
+          '0%, 100%': {
+            transform: 'scale(1)',
+            boxShadow: '0 0 0 0 rgba(124, 58, 237, 0.7)',
+          },
+          '50%': {
+            transform: 'scale(1.08)',
+            boxShadow: '0 0 0 12px rgba(124, 58, 237, 0)',
+          },
         },
       },
       fontFamily: {


### PR DESCRIPTION
## Description

When the browser blocks autoplay, the play button now displays a pulsating animation to guide the user's attention. The animation includes a subtle scale effect (1 → 1.08) combined with an expanding box-shadow, repeating every 1.5 seconds until the user manually clicks play.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Added `autoplayBlocked` state to track when autoplay is prevented by the browser
- Created `pulse-attention` animation in Tailwind config with scale and box-shadow effects
- Updated both StandardPlayer and ZenPlayer to conditionally show the animation when autoplay fails
- Animation automatically stops when user clicks the play button

## Testing

Test in a browser where autoplay is restricted:
1. Visit the site
2. Verify that the play button pulses when the audio fails to autoplay
3. Click the play button to verify the animation stops and audio starts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Adicionada indicação visual de atenção no botão de reprodução quando o autoplay é bloqueado pelo navegador, ajudando a orientar os usuários sobre a necessidade de interação para iniciar a reprodução de áudio.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->