### PR TITLE
fix(docker): create /data directory with correct permissions for yt-dlp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,9 @@ COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/i18n ./i18n
 COPY --from=builder /app/messages ./messages
 
+# Create data directory for YouTube cache and cookies (writable by nextjs)
+RUN mkdir -p /data/youtube-cache && chown -R nextjs:nodejs /data
+
 # Set correct permissions
 RUN chown -R nextjs:nodejs /app
 


### PR DESCRIPTION
## Description

Fixes yt-dlp PermissionError when writing back cookies file. The container runs as `nextjs` (uid 1001) but `/data` directory didn't exist with proper ownership.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Create `/data/youtube-cache` directory in Dockerfile with `nextjs:nodejs` ownership before switching to non-root user

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **Infraestrutura**
  * Aprimorada configuração de ambiente para cache do YouTube e cookies, garantindo criação adequada do diretório de dados e definição de permissões apropriadas para funcionamento em tempo de execução.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->